### PR TITLE
fix: circular parent reference detection

### DIFF
--- a/src/Loader/SiteKitResourceHierarchyLoader.php
+++ b/src/Loader/SiteKitResourceHierarchyLoader.php
@@ -89,10 +89,19 @@ class SiteKitResourceHierarchyLoader implements ResourceHierarchyLoader
     {
         $resource = $this->resourceLoader->load($location);
         $path = [$resource];
+        $loaded = [$resource->location];
         while (!$this->isRoot($resource)) {
             $parent = $this->loadPrimaryParentResource($resource);
+            if (in_array($parent->location, $loaded, true)) {
+                $loaded[] = $parent->location;
+                throw new InvalidResourceException(
+                    $resource->toLocation(),
+                    'circular parent reference detected: ' . implode(' -> ', $loaded),
+                );
+            }
             array_unshift($path, $parent);
             $resource = $parent;
+            $loaded[] = $resource->location;
         }
         return $path;
     }

--- a/test/Loader/SiteKitResourceHierarchyLoaderTest.php
+++ b/test/Loader/SiteKitResourceHierarchyLoaderTest.php
@@ -199,6 +199,22 @@ class SiteKitResourceHierarchyLoaderTest extends TestCase
         );
     }
 
+    public function testLoadPrimaryPathWithSelfRecursion(): void
+    {
+        $this->expectException(InvalidResourceException::class);
+        $this->hierarchyLoader->loadPrimaryPath(
+            ResourceLocation::of('/withSelfRecursion.php'),
+        );
+    }
+
+    public function testLoadPrimaryPathWithRecursion(): void
+    {
+        $this->expectException(InvalidResourceException::class);
+        $this->hierarchyLoader->loadPrimaryPath(
+            ResourceLocation::of('/withRecursionA.php'),
+        );
+    }
+
     public function testLoadPrimaryParentWithoutParent(): void
     {
         $parent = $this->hierarchyLoader->loadPrimaryParent(

--- a/test/resources/Loader/SiteKitNavigationHierarchyLoader/defaultRootNotARoot/a.php
+++ b/test/resources/Loader/SiteKitNavigationHierarchyLoader/defaultRootNotARoot/a.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Atoolo\Resource\Test\TestResourceFactory;
+
+return TestResourceFactory::create([
+    'url' => '/a.php',
+    'id' => 'a',
+    'name' => 'a',
+    'locale' => 'en_US',
+]);

--- a/test/resources/Loader/SiteKitNavigationHierarchyLoader/defaultRootNotARoot/index.php
+++ b/test/resources/Loader/SiteKitNavigationHierarchyLoader/defaultRootNotARoot/index.php
@@ -1,0 +1,11 @@
+<?php
+
+return new \Atoolo\Resource\Resource(
+    '/index.php',
+    'root',
+    'root',
+    '',
+    \Atoolo\Resource\ResourceLanguage::of('de_DE'),
+    new \Atoolo\Resource\DataBag([
+    ]),
+);

--- a/test/resources/Loader/SiteKitResourceHierarchyLoader/withRecursionA.php
+++ b/test/resources/Loader/SiteKitResourceHierarchyLoader/withRecursionA.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Atoolo\Resource\Test\TestResourceFactory;
+
+return TestResourceFactory::create([
+    'url' => '/withRecursionA.php',
+    'id' => 'withRecursionA',
+    'name' => 'withRecursionA',
+    'locale' => 'en_US',
+    'base' => [
+        'trees' => [
+            'category' => [
+                'parents' => [
+                    'withRecursionB' => [
+                        'url' => '/withRecursionB.php',
+                    ],
+                ],
+            ],
+        ],
+    ],
+]);

--- a/test/resources/Loader/SiteKitResourceHierarchyLoader/withRecursionB.php
+++ b/test/resources/Loader/SiteKitResourceHierarchyLoader/withRecursionB.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Atoolo\Resource\Test\TestResourceFactory;
+
+return TestResourceFactory::create([
+    'url' => '/withRecursionB.php',
+    'id' => 'withRecursionB',
+    'name' => 'withRecursionB',
+    'locale' => 'en_US',
+    'base' => [
+        'trees' => [
+            'category' => [
+                'parents' => [
+                    'withRecursionA' => [
+                        'url' => '/withRecursionA.php',
+                    ],
+                ],
+            ],
+        ],
+    ],
+]);

--- a/test/resources/Loader/SiteKitResourceHierarchyLoader/withSelfRecursion.php
+++ b/test/resources/Loader/SiteKitResourceHierarchyLoader/withSelfRecursion.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Atoolo\Resource\Test\TestResourceFactory;
+
+return TestResourceFactory::create([
+    'url' => '/withSelfRecursion.php',
+    'id' => 'withRecursion',
+    'name' => 'withRecursion',
+    'locale' => 'en_US',
+    'base' => [
+        'trees' => [
+            'category' => [
+                'parents' => [
+                    'withRecursion' => [
+                        'url' => '/withSelfRecursion.php',
+                    ],
+                ],
+            ],
+        ],
+    ],
+]);


### PR DESCRIPTION
The aim is to prevent an endless loop when parent links a cicular.