### PR TITLE
fix: don't replace '.' for search-index when using resource-channel-anchor

### DIFF
--- a/src/SiteKitResourceChannelFactory.php
+++ b/src/SiteKitResourceChannelFactory.php
@@ -52,11 +52,8 @@ class SiteKitResourceChannelFactory implements ResourceChannelFactory
 
         $data = $this->loadContextPhpFile();
 
-        $searchIndex = str_replace(
-            '.',
-            '-',
-            $data['publisher']['anchor'],
-        );
+        $searchIndex = $data['publisher']['anchor'];
+
         return new ResourceChannel(
             (string) $data['publisher']['id'],
             $data['publisher']['name'],


### PR DESCRIPTION
Solr now allows dots in the core ID