### PR TITLE
feat: p-parameter service

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,6 +4,14 @@ parameters:
 
 services:
 
+  # default configuration for services in *this* file
+  _defaults:
+    autowire: true      # Automatically injects dependencies in your services.
+    autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+
+  Atoolo\Resource\Service\:
+    resource: '../src/Service'
+
   Atoolo\Resource\Env\EnvVarLoader:
     tags:
       - { name: 'container.env_var_loader', priority: 10 }

--- a/src/Service/PParameterService.php
+++ b/src/Service/PParameterService.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Resource\Service;
+
+use Atoolo\Resource\ResourceHierarchyLoader;
+use Atoolo\Resource\ResourceLoader;
+use Atoolo\Resource\ResourceLocation;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * the P-parameter is used to specify the path of the resource from the root via a
+ * comma-separated list of IDs. This may be necessary if a secondary navigation path
+ * is to be used.
+ *
+ * A special feature is that it is desired for certain use cases that
+ * an article is to be mounted in a foreign navigation node, e.g. search hits below
+ * the search page if the URL is called up via the search result.
+ * This form of the P-parameter is also protected by a signature so that any article
+ * cannot be inserted below any article by manipulating the P-parameter.
+ */
+#[AsAlias(id: 'atoolo_resource.p_parameter_service')]
+class PParameterService
+{
+    public function __construct(
+        #[Autowire(service: 'atoolo_resource.cached_resource_loader')]
+        private readonly ResourceLoader $resourceLoader,
+        #[Autowire(service: 'atoolo_resource.navigation_hierarchy_loader')]
+        private readonly ResourceHierarchyLoader $navigationLoader,
+        #[Autowire(env: 'APP_SECRET')]
+        private readonly string $secret,
+    ) {}
+
+    public function getPParameterForForeignParent(
+        ResourceLocation $foreignParent,
+        ResourceLocation $resourceLocation,
+    ): string {
+        $resource = $this->resourceLoader->load($resourceLocation);
+        $path = $this->navigationLoader->loadPrimaryPath($foreignParent);
+
+        $pParameter = [];
+        for ($i = 0; $i < count($path) - 1; $i++) {
+            $pParameter[] = $path[$i]->id;
+        }
+        $pParameter[] = $path[count($path) - 1]->location;
+        $pParameter[] = $resource->id;
+
+        $p = implode(',', $pParameter);
+        $sig = $this->signPathParam($p);
+        return 'sig:' . $sig . ',' . $p;
+    }
+
+    public function signPathParam(string $path): string
+    {
+        $length = 16;
+        $hmac = hash_hmac('sha256', $path, $this->secret, true);
+        return rtrim(strtr(substr(base64_encode($hmac), 0, $length), '+/', '-_'), '=');
+    }
+}

--- a/test/Service/PParameterServiceTest.php
+++ b/test/Service/PParameterServiceTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Resource\Test\Service;
+
+use Atoolo\Resource\DataBag;
+use Atoolo\Resource\Resource;
+use Atoolo\Resource\ResourceHierarchyLoader;
+use Atoolo\Resource\ResourceLanguage;
+use Atoolo\Resource\ResourceLoader;
+use Atoolo\Resource\ResourceLocation;
+use Atoolo\Resource\Service\PParameterService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PParameterService::class)]
+class PParameterServiceTest extends TestCase
+{
+    private ResourceLoader $resourceLoader;
+    private ResourceHierarchyLoader $navigationLoader;
+    private string $secret;
+    private PParameterService $service;
+
+    /**
+     * @throws Exception
+     */
+    protected function setUp(): void
+    {
+        $this->resourceLoader = $this->createMock(ResourceLoader::class);
+        $this->navigationLoader = $this->createMock(ResourceHierarchyLoader::class);
+        $this->secret = 'test_secret';
+        $this->service = new PParameterService($this->resourceLoader, $this->navigationLoader, $this->secret);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetPParameterForForeignParent()
+    {
+        $foreignParent = $this->createMock(ResourceLocation::class);
+        $resourceLocation = $this->createMock(ResourceLocation::class);
+        $path = [
+            $this->createResource('id1', 'location1'),
+            $this->createResource('id2', 'location2'),
+        ];
+        $resource = $this->createResource('id3', 'location3');
+
+        $this->resourceLoader->method('load')->willReturn($resource);
+        $this->navigationLoader->method('loadPrimaryPath')->willReturn($path);
+
+        $result = $this->service->getPParameterForForeignParent($foreignParent, $resourceLocation);
+
+        $this->assertEquals('sig:McCLYwo4vQOqNINy,id1,location2,id3', $result);
+    }
+
+    public function testSignPathParam()
+    {
+        $result = $this->service->signPathParam('test_path');
+        $this->assertEquals('d4MsWPl4VI1FDEws', $result);
+    }
+
+    private function createResource(string $id, string $location): Resource
+    {
+        return new Resource(
+            location: $location,
+            id: $id,
+            name: '',
+            objectType: '',
+            lang: ResourceLanguage::default(),
+            data: new DataBag([]),
+        );
+    }
+}


### PR DESCRIPTION
The P parameter is used to specify the path of the resource from the root using a comma-separated list of IDs.
This may be necessary if a secondary navigation path is to be used.

A special feature is that it is desired for certain use cases that an article is to be mounted in a foreign navigation node, e.g. search hits below the search page if the URL is called up via the search result.
This form of the P-parameter is also protected by a signature so that any article cannot be inserted below any article by manipulating the P-parameter.