### PR TITLE
feat: add host to ResourceTenant

### DIFF
--- a/src/Factory/SiteKitResourceChannelFactory.php
+++ b/src/Factory/SiteKitResourceChannelFactory.php
@@ -13,6 +13,9 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * @phpstan-type ContextPhp array{
+ *     server: array{
+    *     host: string
+ *     },
  *     tenant: array{
  *         id: string,
  *         name: string,
@@ -74,7 +77,7 @@ class SiteKitResourceChannelFactory implements ResourceChannelFactory
             $this->configDir,
             $searchIndex,
             $data['publisher']['translationLocales'] ?? [],
-            $this->createTenant($data['tenant']),
+            $this->createTenant(array_merge($data['tenant'], ['host' => $data['server']['host']])),
         );
     }
 
@@ -83,6 +86,7 @@ class SiteKitResourceChannelFactory implements ResourceChannelFactory
      *     id: string,
      *     name: string,
      *     anchor: string,
+     *     host: string,
      *     attributes: array<string, mixed>,
      * } $data
      * @return ResourceTenant
@@ -93,6 +97,7 @@ class SiteKitResourceChannelFactory implements ResourceChannelFactory
             (string) $data['id'],
             $data['name'],
             $data['anchor'],
+            $data['host'],
             new DataBag($data['attributes']),
         );
     }

--- a/src/ResourceTenant.php
+++ b/src/ResourceTenant.php
@@ -23,6 +23,7 @@ class ResourceTenant
         public readonly string $id,
         public readonly string $name,
         public readonly string $anchor,
+        public readonly string $host,
         public readonly DataBag $attributes,
     ) {}
 }

--- a/test/Factory/SiteKitResourceChannelFactoryTest.php
+++ b/test/Factory/SiteKitResourceChannelFactoryTest.php
@@ -42,6 +42,7 @@ class SiteKitResourceChannelFactoryTest extends TestCase
                 '2',
                 'Test-Tanent',
                 'test-tanent',
+                'test-host',
                 new DataBag([
                     'abc' => 'cde',
                 ]),
@@ -82,6 +83,7 @@ class SiteKitResourceChannelFactoryTest extends TestCase
                 '2',
                 'Test-Tanent',
                 'test-tanent',
+                'test-host',
                 new DataBag([
                     'abc' => 'cde',
                 ]),

--- a/test/resources/SiteKitResourceChannelFactory/documentRootLayout/WEB-IES/context.php
+++ b/test/resources/SiteKitResourceChannelFactory/documentRootLayout/WEB-IES/context.php
@@ -1,6 +1,9 @@
 <?php
 
 return [
+    'server' => [
+        'host' => 'test-host',
+    ],
     'client' => [
         'id' => '2',
         'name' => 'Test-Tanent',

--- a/test/resources/SiteKitResourceChannelFactory/resourceLayout/context.php
+++ b/test/resources/SiteKitResourceChannelFactory/resourceLayout/context.php
@@ -1,6 +1,9 @@
 <?php
 
 return [
+    'server' => [
+        'host' => 'test-host',
+    ],
     'tenant' => [
         'id' => '2',
         'name' => 'Test-Tanent',


### PR DESCRIPTION
The host is required in the event that a connection to the CMS is to be established. E.g. for the web account login.